### PR TITLE
SCRUM-11 create initial quiz model

### DIFF
--- a/src/main/kotlin/com/reactkotlin/quiz/backend/entity/Quiz.kt
+++ b/src/main/kotlin/com/reactkotlin/quiz/backend/entity/Quiz.kt
@@ -1,0 +1,25 @@
+package com.reactkotlin.quiz.backend.entity
+
+class Quiz(
+    val id: Int,
+    var title: String,
+    var text: String,
+    var options: List<String>,
+    var answers: List<Int>
+) {
+    companion object {
+        private var counter = 0
+
+        fun create(title: String, text: String, options: List<String>, answers: List<Int>): Quiz {
+            counter++
+            return Quiz(
+                id = counter,
+                title = title,
+                text = text,
+                options = options,
+                answers = answers
+            )
+        }
+    }
+
+}

--- a/src/main/kotlin/com/reactkotlin/quiz/backend/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/reactkotlin/quiz/backend/security/SecurityConfig.kt
@@ -1,0 +1,21 @@
+package com.reactkotlin.quiz.backend.security
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+class SecurityConfig {
+
+    @Bean
+    fun filterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .csrf { it.disable() }
+            .authorizeHttpRequests {
+                it.anyRequest().authenticated()
+            }
+            .httpBasic { }
+        return http.build()
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 spring.application.name=QuizApp
+
+spring.security.user.name=test
+spring.security.user.password=test


### PR DESCRIPTION
### Description
-create initial quiz entity model
-add tester spring security user/password variables
-added SecurityConfig to secure all endpoints with HTTP basic authentication and disable CSRF for development ease. This sets up a basic security layer for the project.Which also disables CSRF to simplify API testing (for example PostMan).

### Related Jira: [SCRUM-11] 
jira link : https://react-kotlin.atlassian.net/jira/software/projects/SCRUM/boards/1/backlog?selectedIssue=SCRUM-11