### PR TITLE
SCRUM-46 Added commandLineRunner seeder for test users and roles

### DIFF
--- a/src/main/kotlin/com/reactkotlin/quiz/backend/dataseeder/DataSeederConfig.kt
+++ b/src/main/kotlin/com/reactkotlin/quiz/backend/dataseeder/DataSeederConfig.kt
@@ -1,0 +1,60 @@
+package com.reactkotlin.quiz.backend.dataseeder
+
+import com.reactkotlin.quiz.backend.entity.Role
+import com.reactkotlin.quiz.backend.entity.User
+import com.reactkotlin.quiz.backend.repository.RoleRepository
+import com.reactkotlin.quiz.backend.repository.UserRepository
+import org.slf4j.LoggerFactory
+import org.springframework.boot.CommandLineRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.crypto.password.PasswordEncoder
+
+@Configuration
+class DataSeederConfig {
+
+    private val log = LoggerFactory.getLogger(DataSeederConfig::class.java)
+
+    companion object {
+        private const val ENV_TEST1_PASS = "TEST1_PASS"
+        private const val ENV_TEST2_PASS = "TEST2_PASS"
+        private const val ENV_TEST3_PASS = "TEST3_PASS"
+        private const val ENV_TEST4_PASS = "TEST4_PASS"
+    }
+
+    private val test1Pass: String = System.getenv(ENV_TEST1_PASS)
+    private val test2Pass: String = System.getenv(ENV_TEST2_PASS)
+    private val test3Pass: String = System.getenv(ENV_TEST3_PASS)
+    private val test4Pass: String = System.getenv(ENV_TEST4_PASS)
+
+    @Bean
+    fun dataSeeder(
+        roleRepository: RoleRepository,
+        userRepository: UserRepository,
+        passwordEncoder: PasswordEncoder
+    ) = CommandLineRunner {
+
+        val roles = listOf("USER", "CREATOR", "ADMIN").associateWith { name ->
+            roleRepository.findByName(name) ?: roleRepository.save(Role(name = name))
+        }
+
+        fun seedUser(email: String, rawPassword: String, roleNames: List<String>) {
+            if (userRepository.findByEmail(email) == null) {
+                val userRoles = roleNames.mapNotNull { roles[it] }.toMutableSet()
+                userRepository.save(
+                    User(
+                        email = email,
+                        password = passwordEncoder.encode(rawPassword),
+                        roles = userRoles
+                    )
+                )
+                log.info("✅ Seeded $email with roles $roleNames")
+            }
+        }
+
+        seedUser("test1@abv.bg", test1Pass, listOf("USER", "CREATOR", "ADMIN")) // turbo admin
+        seedUser("test2@abv.bg", test2Pass, listOf("USER"))                     // normal user from when he registers
+        seedUser("test3@abv.bg", test3Pass, listOf("USER", "CREATOR"))          // creator and user
+        seedUser("test4@abv.bg", test4Pass, listOf("CREATOR"))                  // only creator
+    }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -8,14 +8,6 @@ INSERT INTO topics (id, name) VALUES (2, 'Kotlin')
 INSERT INTO topics (id, name) VALUES (3, 'PostgreSQL')
     ON CONFLICT (id) DO NOTHING;
 
--- seed in roles
-INSERT INTO roles (id, name) VALUES (1, 'USER')
-    ON CONFLICT (id) DO NOTHING;
-INSERT INTO roles (id, name) VALUES (2, 'CREATOR')
-    ON CONFLICT (id) DO NOTHING;
-INSERT INTO roles (id, name) VALUES (3, 'ADMIN')
-    ON CONFLICT (id) DO NOTHING;
-
 -- kotlin variable declaration
 INSERT INTO question (title, text)
 VALUES ('Kotlin Variable Declaration', 'How do you declare a read-only integer variable in Kotlin?');


### PR DESCRIPTION
### Description
Added `SeederConfigFile` for seeding in roles and test users
On app start up seed 4 test users with different role combinations(`USER`,`CREATOR`,`ADMIN`)
Moved roles seeding from data.sql to `commandLineRunner` ,since roles are part of security model, theyre closer to business logic than to “trivia data” like topics



### STACKED-PR 
This PR is stacked on #28 
Please review #28 before this

### Jira
This PR resolves jira ticket : https://react-kotlin.atlassian.net/browse/SCRUM-46